### PR TITLE
app image builder feature

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build Bambu Studio AppImage using BuildLinux.sh
         shell: bash
         run: ./BuildLinux.sh -ir
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: AppImage
           path: './build/BambuStudio_ubu64.AppImage'

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,0 +1,32 @@
+name: BambuStudio-SoftFever
+
+on: [push, pull_request]
+
+jobs:
+  appimage-builder:
+    name: Linux AppImage Build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install cmake libgl1-mesa-dev libgtk-3-dev libxkbcommon-dev libunwind-dev libfuse2 -y
+      - name: Install dependencies from BuildLinux.sh
+        shell: bash
+        run: sudo ./BuildLinux.sh -ur
+      - name: Fix permissions
+        shell: bash
+        run: sudo chown $USER -R ./
+      - name: Build Bambu Studio dependencies using BuildLinux.sh
+        shell: bash
+        run: ./BuildLinux.sh -dsr
+      - name: Build Bambu Studio AppImage using BuildLinux.sh
+        shell: bash
+        run: ./BuildLinux.sh -ir
+      - uses: actions/upload-artifact@v2
+        with:
+          name: AppImage
+          path: './build/BambuStudio_ubu64.AppImage'

--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -28,7 +28,7 @@ function check_available_memory_and_disk() {
 }
 
 unset name
-while getopts ":dsiuhgb" opt; do
+while getopts ":dsiuhgbr" opt; do
   case ${opt} in
     u )
         UPDATE_LIB="1"
@@ -48,6 +48,9 @@ while getopts ":dsiuhgb" opt; do
     g )
         FOUND_GTK3=""
         ;;
+    r )
+	SKIP_RAM_CHECK="1"
+	;;
     h ) echo "Usage: ./BuildLinux.sh [-i][-u][-d][-s][-b][-g]"
         echo "   -i: Generate appimage (optional)"
         echo "   -g: force gtk2 build"
@@ -55,6 +58,7 @@ while getopts ":dsiuhgb" opt; do
         echo "   -d: build deps (optional)"
         echo "   -s: build bambu-studio (optional)"
         echo "   -u: only update clock & dependency packets (optional and need sudo)"
+	echo "   -r: skip free ram check (low ram compiling)"
         echo "For a first use, you want to 'sudo ./BuildLinux.sh -u'"
         echo "   and then './BuildLinux.sh -dsi'"
         exit 0
@@ -71,6 +75,7 @@ then
     echo "   -d: build deps (optional)"
     echo "   -s: build bambu-studio (optional)"
     echo "   -u: only update clock & dependency packets (optional and need sudo)"
+    echo "   -r: skip free ram check (low ram compiling)"
     echo "For a first use, you want to 'sudo ./BuildLinux.sh -u'"
     echo "   and then './BuildLinux.sh -dsi'"
     exit 0
@@ -153,7 +158,10 @@ then
     mkdir deps/build
 fi
 
+if ! [[ -n "$SKIP_RAM_CHECK" ]]
+then
 check_available_memory_and_disk
+fi
 
 if [[ -n "$BUILD_DEPS" ]]
 then

--- a/deps/wxWidgets/wxWidgets.cmake
+++ b/deps/wxWidgets/wxWidgets.cmake
@@ -1,6 +1,7 @@
 set(_wx_git_tag v3.1.5)
 
 set(_wx_toolkit "")
+set(_wx_glcanvas_egl "")
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(_gtk_ver 2)
     if (DEP_WX_GTK3)
@@ -8,6 +9,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     endif ()
     set(_wx_toolkit "-DwxBUILD_TOOLKIT=gtk${_gtk_ver}")
     set(_wx_private_font "-DwxUSE_PRIVATE_FONTS=1")
+    set(_wx_glcanvas_egl "-DwxUSE_GLCANVAS_EGL=OFF")
 else ()
     set(_wx_private_font "-DwxUSE_PRIVATE_FONTS=0")
 endif()
@@ -49,7 +51,7 @@ bambustudio_add_cmake_project(wxWidgets
         -DwxUSE_LIBJPEG=sys
         -DwxUSE_LIBTIFF=sys
         -DwxUSE_EXPAT=sys
-        -DwxUSE_GLCANVAS_EGL=OFF
+	${_wx_glcanvas_egl}
 )
 
 if (MSVC)

--- a/deps/wxWidgets/wxWidgets.cmake
+++ b/deps/wxWidgets/wxWidgets.cmake
@@ -49,6 +49,7 @@ bambustudio_add_cmake_project(wxWidgets
         -DwxUSE_LIBJPEG=sys
         -DwxUSE_LIBTIFF=sys
         -DwxUSE_EXPAT=sys
+        -DwxUSE_GLCANVAS_EGL=OFF
 )
 
 if (MSVC)

--- a/src/platform/unix/build_appimage.sh.in
+++ b/src/platform/unix/build_appimage.sh.in
@@ -7,6 +7,10 @@ APP_IMAGE="@SLIC3R_APP_KEY@_ubu64.AppImage"
 wget ${APPIMAGETOOLURL} -O ../appimagetool.AppImage
 chmod +x ../appimagetool.AppImage
 
+if [ -f /.dockerenv ] ; then # Only run if inside of a Docker Container
+sed '0,/AI\x02/{s|AI\x02|\x00\x00\x00|}' -i  ../appimagetool.AppImage
+fi
+
 sed -i -e 's#/usr#././#g' bin/@SLIC3R_APP_CMD@
 mv @SLIC3R_APP_CMD@ AppRun
 chmod +x AppRun
@@ -25,6 +29,11 @@ MimeType=model/stl;application/vnd.ms-3mfdocument;application/prs.wavefront-obj;
 EOF
 
 
-../appimagetool.AppImage . $([ ! -z "${container}" ] && echo '--appimage-extract-and-run')
+if [ -f /.dockerenv ] ; then # Only run if inside of a Docker Container
+  ../appimagetool.AppImage --appimage-extract-and-run . $([ ! -z "${container}" ] && echo '--appimage-extract-and-run')
+else
+  ../appimagetool.AppImage . $([ ! -z "${container}" ] && echo '--appimage-extract-and-run')
+fi
+
 mv @SLIC3R_APP_KEY@-x86_64.AppImage ${APP_IMAGE}
 chmod +x ${APP_IMAGE}


### PR DESCRIPTION
I have created a PR to create AppImages using GitHub Actions Workflow. 

The main modification I made was add a flag to BuildLinux.sh so it'll skip the memory check as it's not a problem to compile with less ram. That ram check could be removed but I've just simply added a flag to skip it. 

I also added a check to see if you are attempting to run the appimage build in a docker container so it'll patch the appimagetool so it'll run and use the extract and run option in that scenario. GH Action workflow isn't in a container but when testing with [nektos/act](https://github.com/nektos/act) it was needed to confirm the build was working correctly. 

I've incorporated @zhaofengli 's fix  [Disable EGL for wxGLCanvas](https://github.com/zhaofengli/BambuStudio/tree/wx-no-egl) with my PR to get the appimage to work properly. 

I'm sending a similar PR to BambuStudio upstream, but this one does have an issue with the AppImage producing an error when running the application:
![image](https://user-images.githubusercontent.com/649502/210160629-99b9c37d-817e-432a-ad54-889de8172900.png)

"Error running Javascript: file:///tmp/.mount_BambuSKzd8iH/resources/web/homepage/index.html?lang=en_GB:1:9: ReferenceError: Can't find variable: __wxOut0"

Not entirely sure what's triggering that as it's not happening to upstream Bambu Studio.
