### PR TITLE
Force using of monotonic infill pattern for internal solid infill.

### DIFF
--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -165,7 +165,7 @@ std::vector<SurfaceFill> group_fills(const Layer &layer)
                     }
                     else {
                         if(region_config.top_surface_pattern == ipMonotonic || region_config.top_surface_pattern == ipMonotonicLine)
-                            params.pattern = region_config.top_surface_pattern;
+                            params.pattern = ipMonotonic;
                         else
                             params.pattern = ipRectilinear;
                     }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3881,7 +3881,7 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
                 gcode += m_writer.extrude_to_xy(
                     this->point_to_gcode(line.b),
                     e_per_mm * line_length,
-                    comment);
+                    comment, path.is_force_no_extrusion());
             }
         } else {
             // BBS: start to generate gcode from arc fitting data which includes line and arc


### PR DESCRIPTION
In case of using Monotonic Line pattern as Top surface pattern our internal solid infills will have a lot of redundant gap fills.
![image](https://user-images.githubusercontent.com/1551942/213967855-af7a56e6-ffdd-419f-bdd8-be76171db7a5.png)
This is second layer of 10 bottom layers and each will have the same gap fills, with more complex geometry it will be even worse. Prusa Slicer do not have "Monotonic Line" pattern at all so we do not have such problem. In case if we want to have "Monotonic Line" pattern as option for the topmost layers, it will be much faster to force internal infills by monotonic one. If we want to provide control over internal solid infill, it would be more clear to make separate GUI controls for this.

Additionally I have fixed issue "Patterntype for Solid and top layer #134"