### PR TITLE
Option for klipper only: Adjustment of "accel_to_decel"

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -174,13 +174,13 @@ std::string GCodeWriter::set_acceleration(unsigned int acceleration)
         // This is new MarlinFirmware with separated print/retraction/travel acceleration.
         // Use M204 P, we don't want to override travel acc by M204 S (which is deprecated anyway).
         gcode << "M204 P" << acceleration;
-    } else if (FLAVOR_IS(gcfKlipper) && this->config.adjust_accel_to_decel.value) {
-        gcode << "SET_VELOCITY_LIMIT ACCEL_TO_DECEL=" << acceleration * 0.5;
-        if (GCodeWriter::full_gcode_comment) gcode << " ; adjust max_accel_to_decel to 0.5 of new accel value\n";
+    } else if (FLAVOR_IS(gcfKlipper) && this->config.accel_to_decel_enable) {
+        gcode << "SET_VELOCITY_LIMIT ACCEL_TO_DECEL=" << acceleration * this->config.accel_to_decel_factor / 100;
+        if (GCodeWriter::full_gcode_comment)
+            gcode << " ; adjust max_accel_to_decel to chosen % of new accel value\n";
         gcode << "M204 S" << acceleration;
         // Set max accel to decel to half of acceleration
-    }
-    else
+    } else
         gcode << "M204 S" << acceleration;
     
     //BBS

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -174,10 +174,15 @@ std::string GCodeWriter::set_acceleration(unsigned int acceleration)
         // This is new MarlinFirmware with separated print/retraction/travel acceleration.
         // Use M204 P, we don't want to override travel acc by M204 S (which is deprecated anyway).
         gcode << "M204 P" << acceleration;
-    } else {
-        // M204: Set default acceleration
+    } else if (FLAVOR_IS(gcfKlipper) && this->config.adjust_accel_to_decel.value) {
+        gcode << "SET_VELOCITY_LIMIT ACCEL_TO_DECEL=" << acceleration * 0.5;
+        if (GCodeWriter::full_gcode_comment) gcode << " ; adjust max_accel_to_decel to 0.5 of new accel value\n";
         gcode << "M204 S" << acceleration;
+        // Set max accel to decel to half of acceleration
     }
+    else
+        gcode << "M204 S" << acceleration;
+    
     //BBS
     if (GCodeWriter::full_gcode_comment) gcode << " ; adjust acceleration";
     gcode << "\n";

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -752,7 +752,7 @@ static std::vector<std::string> s_Preset_print_options {
      "small_perimeter_speed", "small_perimeter_threshold","bridge_angle", "filter_out_gap_fill", "post_process", "travel_acceleration","inner_wall_acceleration",
      "default_jerk", "outer_wall_jerk", "inner_wall_jerk", "infill_jerk", "top_surface_jerk", "initial_layer_jerk","travel_jerk",
      "top_solid_infill_flow_ratio","bottom_solid_infill_flow_ratio","only_one_wall_first_layer",
-     "print_flow_ratio","seam_gap","role_based_wipe_speed","wipe_speed","adjust_accel_to_decel"
+     "print_flow_ratio","seam_gap","role_based_wipe_speed","wipe_speed","accel_to_decel_enable", "accel_to_decel_factor"
 
 };
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -752,7 +752,7 @@ static std::vector<std::string> s_Preset_print_options {
      "small_perimeter_speed", "small_perimeter_threshold","bridge_angle", "filter_out_gap_fill", "post_process", "travel_acceleration","inner_wall_acceleration",
      "default_jerk", "outer_wall_jerk", "inner_wall_jerk", "infill_jerk", "top_surface_jerk", "initial_layer_jerk","travel_jerk",
      "top_solid_infill_flow_ratio","bottom_solid_infill_flow_ratio","only_one_wall_first_layer",
-     "print_flow_ratio","seam_gap","role_based_wipe_speed","wipe_speed"
+     "print_flow_ratio","seam_gap","role_based_wipe_speed","wipe_speed","adjust_accel_to_decel"
 
 };
 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -103,7 +103,6 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "outer_wall_acceleration",
         "inner_wall_acceleration",
         "initial_layer_acceleration",
-        "outer_wall_acceleration",
         "top_surface_acceleration",
         "travel_acceleration",
         // BBS
@@ -153,7 +152,8 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "seam_gap",
         "role_based_wipe_speed",
         "wipe_speed",
-        "use_relative_e_distances"
+        "use_relative_e_distances",
+        "adjust_accel_to_decel"
     };
 
     static std::unordered_set<std::string> steps_ignore;

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -153,7 +153,8 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "role_based_wipe_speed",
         "wipe_speed",
         "use_relative_e_distances",
-        "adjust_accel_to_decel"
+        "accel_to_decel_enable",
+        "accel_to_decel_factor"
     };
 
     static std::unordered_set<std::string> steps_ignore;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1452,12 +1452,20 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(300));
 
-    def = this->add("adjust_accel_to_decel", coBool);
-    def->label = L("Auto. adjust accel_to_decel");
-    def->tooltip = L("Max_accel_to_decel will be adjusted automatically to 50% of acceleration setting (M204)");
-    def->sidetext = L("50% of acceleration");
+    def = this->add("accel_to_decel_enable", coBool);
+    def->label = L("Adjust accel to decel");
+    def->tooltip = L("Klipper's max_accel_to_decel will be adjusted automatically");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
+    
+    def = this->add("accel_to_decel_factor", coPercent);
+    def->label = L("% of acceleration");
+    def->tooltip = L("Klipper's Max_accel_to_decel will be adjusted to this % of acceleration");
+    def->sidetext = L("%");
+    def->min = 1;
+    def->max = 100;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionPercent(50));
     
     def = this->add("default_jerk", coFloat);
     def->label = L("Default");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1168,7 +1168,7 @@ void PrintConfigDef::init_fff_params()
 
     def = this->add("pressure_advance", coFloats);
     def->label = L("Pressure advance");
-    def->tooltip = L("Pressure advnce(Klipper) AKA Linear advance factor(Marlin)");
+    def->tooltip = L("Pressure advance(Klipper) AKA Linear advance factor(Marlin)");
     def->max = 2;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloats { 0.02 });
@@ -1452,6 +1452,13 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(300));
 
+    def = this->add("adjust_accel_to_decel", coBool);
+    def->label = L("Auto. adjust accel_to_decel");
+    def->tooltip = L("Max_accel_to_decel will be adjusted automatically to 50% of acceleration setting (M204)");
+    def->sidetext = L("50% of acceleration");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+    
     def = this->add("default_jerk", coFloat);
     def->label = L("Default");
     def->tooltip = L("Default");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -854,7 +854,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     // SoftFever
     ((ConfigOptionBool,                use_firmware_retraction))
     ((ConfigOptionBool,                use_relative_e_distances))
-    ((ConfigOptionBool,                adjust_accel_to_decel))
+    ((ConfigOptionBool,                accel_to_decel_enable))
+    ((ConfigOptionPercent,             accel_to_decel_factor))
 )
 
 // This object is mapped to Perl as Slic3r::Config::Print.

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -854,6 +854,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     // SoftFever
     ((ConfigOptionBool,                use_firmware_retraction))
     ((ConfigOptionBool,                use_relative_e_distances))
+    ((ConfigOptionBool,                adjust_accel_to_decel))
 )
 
 // This object is mapped to Perl as Slic3r::Config::Print.

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -508,6 +508,10 @@ void ConfigManipulation::apply_null_fff_config(DynamicPrintConfig *config, std::
 
 void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, const bool is_global_config)
 {
+    PresetBundle *preset_bundle  = wxGetApp().preset_bundle;
+    //SoftFever
+    auto gcflavor = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor")->value;
+    
     bool have_perimeters = config->opt_int("wall_loops") > 0;
     for (auto el : { "ensure_vertical_shell_thickness", "detect_thin_wall", "detect_overhang_wall",
                     "seam_position", "wall_infill_order", "outer_wall_line_width",
@@ -644,7 +648,6 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
         toggle_line(el, has_fuzzy_skin);
 
     // C11 printer is not support smooth timelapse
-    PresetBundle *preset_bundle  = wxGetApp().preset_bundle;
     std::string str_preset_type = preset_bundle->printers.get_edited_preset().get_printer_type(preset_bundle);
     toggle_field("timelapse_type", str_preset_type != "C11");
 
@@ -660,10 +663,11 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     auto is_role_based_wipe_speed = config->opt_bool("role_based_wipe_speed");
     toggle_field("wipe_speed",!is_role_based_wipe_speed);
     
-    //SoftFever: whether the firmware is Klipper
-    bool is_klipper = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor")->value == gcfKlipper;
-
-    toggle_line("adjust_accel_to_decel", is_klipper);
+    // SoftFever
+    for (auto el : {"accel_to_decel_enable", "accel_to_decel_factor"})
+        toggle_line(el, gcflavor == gcfKlipper);
+    
+    toggle_line("accel_to_decel_factor", config->opt_bool("accel_to_decel_enable"));
 }
 
 void ConfigManipulation::update_print_sla_config(DynamicPrintConfig* config, const bool is_global_config/* = false*/)

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -660,6 +660,10 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     auto is_role_based_wipe_speed = config->opt_bool("role_based_wipe_speed");
     toggle_field("wipe_speed",!is_role_based_wipe_speed);
     
+    //SoftFever: whether the firmware is Klipper
+    bool is_klipper = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor")->value == gcfKlipper;
+
+    toggle_line("adjust_accel_to_decel", is_klipper);
 }
 
 void ConfigManipulation::update_print_sla_config(DynamicPrintConfig* config, const bool is_global_config/* = false*/)

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1939,6 +1939,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("initial_layer_acceleration");
         optgroup->append_single_option_line("top_surface_acceleration");
         optgroup->append_single_option_line("travel_acceleration");
+        optgroup->append_single_option_line("adjust_accel_to_decel");
 
         optgroup = page->new_optgroup(L("Jerk(XY)"));
         optgroup->append_single_option_line("default_jerk");
@@ -3643,7 +3644,7 @@ void TabPrinter::toggle_options()
     }
 
     auto gcf = m_config->option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor")->value;
-        if (m_active_page->title() == "Motion ability") {
+    if (m_active_page->title() == "Motion ability") {
         assert(gcf == gcfMarlinLegacy || gcf == gcfMarlinFirmware || gcf == gcfKlipper);
         bool silent_mode = m_config->opt_bool("silent_mode");
         int  max_field = silent_mode ? 2 : 1;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1939,7 +1939,8 @@ void TabPrint::build()
         optgroup->append_single_option_line("initial_layer_acceleration");
         optgroup->append_single_option_line("top_surface_acceleration");
         optgroup->append_single_option_line("travel_acceleration");
-        optgroup->append_single_option_line("adjust_accel_to_decel");
+        optgroup->append_single_option_line("accel_to_decel_enable");
+        optgroup->append_single_option_line("accel_to_decel_factor");
 
         optgroup = page->new_optgroup(L("Jerk(XY)"));
         optgroup->append_single_option_line("default_jerk");


### PR DESCRIPTION
Add option to automatically adjust accel_to_decel to 50% of chosen acceleration. This option is only displayed when using klipper.

<img width="462" alt="image" src="https://user-images.githubusercontent.com/29361809/214094922-c018824e-97c1-415c-9893-1e4fb0ed7317.png">
