### PR TITLE
Cleanup DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake 3.24

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -23,6 +23,10 @@
 project(BambuStudio-deps)
 cmake_minimum_required(VERSION 3.2)
 
+if(POLICY CMP0135) # DOWNLOAD_EXTRACT_TIMESTAMP
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 include(ExternalProject)
 include(ProcessorCount)
 


### PR DESCRIPTION
CMake 3.24 introduces a new policy for managing timestamps on extracted contents of downloaded archives. This change specifies the new behavior should be used for dependencies to eliminate the warning printed when the policy is not set.